### PR TITLE
Piranha 10 / dotnet 6 migration

### DIFF
--- a/src/Flagscript.PiranhaCms.Aws.S3Storage/Flagscript.PiranhaCms.Aws.S3Storage.csproj
+++ b/src/Flagscript.PiranhaCms.Aws.S3Storage/Flagscript.PiranhaCms.Aws.S3Storage.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <PackOnBuild>false</PackOnBuild>
     <PackageVersion>1.0.1</PackageVersion>
     <Authors>Greg Kaestle, Flagscript</Authors>
@@ -27,9 +27,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.S3" Version="3.3.0" />
-    <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="3.3.100.1" />
-    <PackageReference Include="Piranha" Version="6.0.0" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.5" />
+    <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="3.7.1" />
+    <PackageReference Include="Piranha" Version="10.0.0" />
     <PackageReference Include="Flurl" Version="2.4.0" />
     <PackageReference Include="Flagscript" Version="3.1.0" />
   </ItemGroup>

--- a/src/Flagscript.PiranhaCms.Aws.S3Storage/S3Storage.cs
+++ b/src/Flagscript.PiranhaCms.Aws.S3Storage/S3Storage.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.Logging;
 using Amazon.Extensions.NETCore.Setup;
 using Flurl;
 using Piranha;
+using Piranha.Models;
 
 namespace Flagscript.PiranhaCms.Aws.S3Storage
 {
@@ -58,23 +59,35 @@ namespace Flagscript.PiranhaCms.Aws.S3Storage
 		public Task<IStorageSession> OpenAsync()
 		{
 			Logger?.LogDebug("Opening Piranha S3 media storage session");
-			return Task.FromResult<IStorageSession>(new S3StorageSession(StorageOptions, AwsOptions, Logger));
+			return Task.FromResult<IStorageSession>(new S3StorageSession(StorageOptions, AwsOptions, this, Logger));
 		}
 
 		/// <summary>
 		/// Gets the public URL for the given media object.
 		/// </summary>
-		/// <param name="id">The media resource id</param>
+		/// <param name="media">The media resource</param>
+		/// <param name="filename">The associated file name</param>
 		/// <returns>The public URL.</returns>
-		public string GetPublicUrl(string id)
-		{
-			if (!string.IsNullOrWhiteSpace(id))
+		public string GetPublicUrl(Media media, string filename)
+        {
+			if (media != null && !string.IsNullOrWhiteSpace(filename))
 			{
-				return Url.Combine(StorageOptions.PublicUrlPrefix, id);
+				return Url.Combine(StorageOptions.PublicUrlPrefix, media.Id.ToString(), System.Web.HttpUtility.UrlPathEncode(filename));
 			}
 			return null;
 		}
 
-	}
+		/// <summary>
+		/// Returns the resource name for the specified media and filename
+		/// </summary>
+		/// <param name="media">The media resource</param>
+		/// <param name="filename">The associated file name</param>
+		/// <returns></returns>
+		public string GetResourceName(Media media, string filename)
+        {
+			var objectKey = Url.Combine(StorageOptions.KeyPrefix, media.Id.ToString(), System.Web.HttpUtility.UrlPathEncode(filename));
+			return objectKey;
+		}
+    }
 
 }


### PR DESCRIPTION
There seems to have been several breaking changes in Piranha from v6 to v10.
- Sdk version targeted is now dotnet6
- Interfaces for IStorage and IStorageSession have changed drammatically

I love this library but using a more recent version of Piranha, i thought i had to change it so i could use it properly. 
Those are breaking changes though so i'm thinking maybe this could be pulled into a branch and released under a new version? 
I'm linking directly to the project locally at the moment.